### PR TITLE
fix issue with a "SOAPAction;" header

### DIFF
--- a/src/VCR/Util/CurlHelper.php
+++ b/src/VCR/Util/CurlHelper.php
@@ -173,6 +173,10 @@ class CurlHelper
                     if (!isset($headerParts[1])) {
                         $headerParts[0] = rtrim($headerParts[0], ':');
                         $headerParts[1] = '';
+                        if (strpos($headerParts[0], ';') !== false) {       // new lines here
+                            $headerParts[0] = rtrim($headerParts[0], ';');
+                            $headerParts[1] = ';';
+                        }  
                     }
                     $request->setHeader($headerParts[0], $headerParts[1]);
                 }


### PR DESCRIPTION
### Context
See this issue https://github.com/php-vcr/php-vcr/issues/308#issuecomment-812954737

### What has been done

- Updated curl helper to handle a SOAPAction header with this format: "SOAPAction;"

### How to test

- TODO

### Todo

- [  ] test compatibility

### Notes


